### PR TITLE
Add route and service tests

### DIFF
--- a/tests/test_candidate_routes.py
+++ b/tests/test_candidate_routes.py
@@ -1,0 +1,32 @@
+from tests.test_api_routes import signup_candidate, signup_client, login
+
+
+def test_candidate_full_profile_endpoints(client):
+    signup_candidate(client, 'cand1')
+    login(client, 'cand1')
+    # fetch own candidate id from login response
+    cand_id = client.post('/api/auth/login', json={'username':'cand1','password':'pass'},
+                          environ_base={'wsgi.url_scheme':'https','REMOTE_ADDR':'cand1'}).get_json()['candidate_id']
+
+    resp = client.get(f'/api/candidate/{cand_id}/full', environ_base={'wsgi.url_scheme':'https'})
+    assert resp.status_code == 200
+    assert resp.get_json()['profile']['id'] == cand_id
+
+    # patch profile
+    resp = client.patch(f'/api/candidate/{cand_id}/full', json={'profile': {'full_name': 'Updated'}},
+                        environ_base={'wsgi.url_scheme':'https'})
+    assert resp.status_code == 200
+
+    resp = client.get(f'/api/candidate/{cand_id}/full', environ_base={'wsgi.url_scheme':'https'})
+    assert resp.get_json()['profile']['full_name'] == 'Updated'
+
+    # apply job (dummy endpoint)
+    resp = client.post('/api/candidate/apply', json={'job_id': 1}, environ_base={'wsgi.url_scheme':'https'})
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == 'Application submitted'
+
+    # list applications (dummy data)
+    resp = client.get('/api/candidate/applications', environ_base={'wsgi.url_scheme':'https'})
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json()['applications'], list)
+

--- a/tests/test_client_routes.py
+++ b/tests/test_client_routes.py
@@ -1,0 +1,28 @@
+from tests.test_api_routes import signup_client, signup_candidate, login
+
+
+def test_client_dashboard_and_company_endpoints(client):
+    signup_client(client, 'comp')
+    login(client, 'comp')
+    # login again to get company id
+    comp_id = client.post('/api/auth/login', json={'username':'comp','password':'pass'},
+                          environ_base={'wsgi.url_scheme':'https','REMOTE_ADDR':'comp'}).get_json()['company_id']
+
+    # dashboard should return company data
+    resp = client.get('/api/client/', environ_base={'wsgi.url_scheme':'https'})
+    assert resp.status_code in (200, 404)
+    if resp.status_code == 200:
+        assert resp.get_json()['company']['id'] == comp_id
+
+    # get specific company info
+    resp = client.get(f'/api/client/{comp_id}', environ_base={'wsgi.url_scheme':'https'})
+    assert resp.status_code == 200
+    assert resp.get_json()['id'] == comp_id
+
+    # update company
+    resp = client.patch(f'/api/client/{comp_id}', json={'name': 'NewName', 'bio': '<b>bold</b>'},
+                        environ_base={'wsgi.url_scheme':'https'})
+    assert resp.status_code == 200
+    assert resp.get_json()['name'] == 'NewName'
+    assert resp.get_json()['bio'] == '<b>bold</b>'
+


### PR DESCRIPTION
## Summary
- add tests for candidate profile routes
- add tests for client dashboard routes
- test chat participants and registration
- broaden db service tests for both candidate and company

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445aa542188332b7ddb6305b73111e