### PR TITLE
Add coverage and frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Run backend tests
-        run: pytest
+      - name: Run backend tests with coverage
+        run: |
+          pytest --cov=backend --cov-report=xml
+      - name: Upload backend coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: coverage.xml
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@eslint/js": "^9.22.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1473,6 +1474,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@eslint/js": "^9.22.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/src/components/chat/Conversation.test.jsx
+++ b/frontend/src/components/chat/Conversation.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Conversation from './Conversation'
+import React from 'react'
+import { vi } from 'vitest'
+
+test('shows placeholder when no conversation', () => {
+  render(<Conversation conversation={null} />)
+  expect(screen.getByText('Select a conversation to view messages')).toBeInTheDocument()
+})
+
+test('applies active class when isActive', () => {
+  const conv = { id: 1, last_message: { body: 'hi' }, unread_count: 0 }
+  render(<Conversation conversation={conv} isActive={true} onSelect={() => {}} />)
+  expect(screen.getByRole('button').className).toContain('conversation--active')
+})
+
+test('calls onSelect when clicked', async () => {
+  const conv = { id: 2, last_message: { body: 'hey' }, unread_count: 0 }
+  const onSelect = vi.fn()
+  render(<Conversation conversation={conv} isActive={false} onSelect={onSelect} />)
+  await userEvent.click(screen.getByRole('button'))
+  expect(onSelect).toHaveBeenCalledWith(2)
+})

--- a/frontend/src/components/marketplace/lists/CandidatesList.test.jsx
+++ b/frontend/src/components/marketplace/lists/CandidatesList.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import CandidatesList from './CandidatesList'
+import React from 'react'
+import { vi } from 'vitest'
+import api from '../../../services/api'
+
+vi.mock('../../../services/api', () => ({ default: { get: vi.fn() } }))
+
+test('renders candidates from api', async () => {
+  api.get.mockResolvedValue({ data: { candidates: [{ id: 1, name: 'Bob', role: 'Dev' }] } })
+  render(<CandidatesList />)
+  expect(api.get).toHaveBeenCalledWith('/candidates')
+  await waitFor(() => expect(screen.getByText('Bob')).toBeInTheDocument())
+})

--- a/frontend/src/components/marketplace/lists/CompaniesList.test.jsx
+++ b/frontend/src/components/marketplace/lists/CompaniesList.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import CompaniesList from './CompaniesList'
+import React from 'react'
+import { vi } from 'vitest'
+import api from '../../../services/api'
+
+vi.mock('../../../services/api', () => ({ default: { get: vi.fn() } }))
+
+test('shows error when api fails', async () => {
+  api.get.mockRejectedValue({ response: { data: { error: 'fail' } } })
+  render(<CompaniesList />)
+  await waitFor(() => expect(screen.getByText(/fail/)).toBeInTheDocument())
+})

--- a/frontend/src/components/marketplace/lists/JobsList.test.jsx
+++ b/frontend/src/components/marketplace/lists/JobsList.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import JobsList from './JobsList'
+import React from 'react'
+import { vi } from 'vitest'
+import api from '../../../services/api'
+
+vi.mock('../../../services/api', () => ({ default: { get: vi.fn() } }))
+
+test('shows message when no jobs', async () => {
+  api.get.mockResolvedValue({ data: { jobs: [] } })
+  render(<JobsList />)
+  await waitFor(() => expect(screen.getByText('No jobs found')).toBeInTheDocument())
+})

--- a/frontend/src/components/profiles/ProfileCard.test.jsx
+++ b/frontend/src/components/profiles/ProfileCard.test.jsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import ProfileCard from './ProfileCard'
+import React from 'react'
+
+test('renders title and fields', () => {
+  const fields = [{ label: 'Name', value: 'Alice' }]
+  render(<ProfileCard title="Info" fields={fields} />)
+  expect(screen.getByText('Info')).toBeInTheDocument()
+  expect(screen.getByText('Name:')).toBeInTheDocument()
+  expect(screen.getByText('Alice')).toBeInTheDocument()
+})

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ bleach
 PyJWT
 pytest
 pytest-flask
+pytest-cov


### PR DESCRIPTION
## Summary
- track coverage in CI workflow
- include pytest-cov in requirements
- add missing React component tests
- add user-event test dependency

## Testing
- `npm test -- --run`
- `pytest --cov=backend --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68445ecaab2c8332b135175d9225b2e2